### PR TITLE
Update build command with static linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 chimney: *.go
-	go build .
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
 
 build:
 	docker run --rm -v $(ROOT_DIR):/src -v /var/run/docker.sock:/var/run/docker.sock centurylink/golang-builder ccnmtl/chimney


### PR DESCRIPTION
Making the binary more portable, and less likely for problems wherever
we run it.

From: http://blog.wrouesnel.com/articles/Totally%20static%20Go%20builds/